### PR TITLE
Add abiltity to run react skeletons under a hash based strict CSP

### DIFF
--- a/base/template.json
+++ b/base/template.json
@@ -31,7 +31,8 @@
       "lint": "npm-run-all lint:*",
       "lint:eslint": "eslint ./src --ext .js,.jsx,.ts,.tsx --cache",
       "upload-build": "cross-env rsync -avPx build/* ${npm_package_name}@${npm_config_host}:~/public/$FOLDER --delete-after",
-      "deploy": "ts-node-transpile-only --script-mode build-tools/scripts/deploy.ts"
+      "deploy": "ts-node-transpile-only --script-mode build-tools/scripts/deploy.ts",
+      "postbuild": "ts-node-transpile-only --script-mode build-tools/scripts/clean-index-template.ts"
     }
   }
 }

--- a/base/template/.env
+++ b/base/template/.env
@@ -1,0 +1,1 @@
+INLINE_RUNTIME_CHUNK=false

--- a/base/template/README.md
+++ b/base/template/README.md
@@ -61,3 +61,10 @@ You can learn more in the
 [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+## Content Security Policy ([CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP))
+
+This application has been build with a [strict content security policy](https://csp.withgoogle.com/docs/strict-csp.html). To enforce this policy
+add the following CSP header to the request response.
+
+`Content-Security-Policy: script-src 'sha256-+OVgFCkyF2/rZ6qyfsNnIisCRI6dtMZw3w0Y4xiYagw=' 'strict-dynamic' https: 'unsafe-inline'; object-src 'none'; base-uri 'none';`

--- a/base/template/build-tools/scripts/clean-index-template.ts
+++ b/base/template/build-tools/scripts/clean-index-template.ts
@@ -1,0 +1,14 @@
+import * as path from 'path';
+import { readFile, writeFile } from 'fs/promises';
+
+/**
+ * This script executes post build and rewrites the index.html file removing
+ * injected scripts from the build.
+ */
+(async () => {
+  const index = path.resolve('./build/index.html');
+  const contents = await readFile(index, { encoding: 'utf-8' });
+  const cleaned = contents.replace(/<script src="[\w\d-\/]*static\/js\/[\w\d\.-]*"><\/script>/ig,'');
+
+  await writeFile(index, cleaned, { encoding: 'utf-8' });
+})();

--- a/base/template/public/index.html
+++ b/base/template/public/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8" />
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
@@ -8,6 +7,14 @@
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Web site created using create-react-app" />
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon.ico" />
+
+  <% if(process.env.NODE_ENV === 'development') { %>
+  <meta http-equiv="Content-Security-Policy" content="script-src 'sha256-+OVgFCkyF2/rZ6qyfsNnIisCRI6dtMZw3w0Y4xiYagw=' 'strict-dynamic' https: 'unsafe-inline'; object-src 'none'; base-uri 'none';">
+  <% } %>
+
+  <% for (var chunk in htmlWebpackPlugin.files.js) { %>
+  <meta name="app-script" content="<%= htmlWebpackPlugin.files.js[chunk]%>" />
+  <% } %>
   <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -23,18 +30,23 @@
     -->
   <title>React App</title>
 </head>
-
 <body>
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root"></div>
-  <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-</body>
+<noscript>You need to enable JavaScript to run this app.</noscript>
+<div id="root"></div>
+<!--
+    This HTML file is a template.
+    If you open it directly in the browser, you will see an empty page.
+    You can add webfonts, meta tags, or analytics to this file.
+    The build step will place the bundled scripts into the <body> tag.
+    To begin the development, run `npm start` or `yarn start`.
+    To create a production bundle, use `npm run build` or `yarn build`.
+  -->
 
+<script>!function(){for(var o=document.querySelectorAll('html > head > meta[name="app-script"]'),t=0;t<o.length;t++){var e=o[t].getAttribute("content"),n=document.createElement("script");n.src=e,n.src.substr(0,window.location.origin.length)!==window.location.origin?window.console&&console.error("[ScriptLoader] Cannot load "+e+"."):document.body.appendChild(n)}}()</script>
+
+<% if(process.env.NODE_ENV === 'development') { %>
+<!-- workaround to skip cra automatic script injection -->
+<!-- </body></html>-->
+<% } %>
+</body>
 </html>

--- a/standard/template.json
+++ b/standard/template.json
@@ -53,7 +53,8 @@
       "upload-build": "cross-env rsync -avPx build/* ${npm_package_name}@${npm_config_host}:~/public/$FOLDER --delete-after",
       "deploy": "ts-node-transpile-only --script-mode build-tools/scripts/deploy.ts",
       "storybook": "start-storybook -p 3001 -s public --no-dll",
-      "build-storybook": "build-storybook -s public --no-dll"
+      "build-storybook": "build-storybook -s public --no-dll",
+      "postbuild": "ts-node-transpile-only --script-mode build-tools/scripts/clean-index-template.ts"
     }
   }
 }

--- a/standard/template/.env
+++ b/standard/template/.env
@@ -1,0 +1,1 @@
+INLINE_RUNTIME_CHUNK=false

--- a/standard/template/README.md
+++ b/standard/template/README.md
@@ -61,3 +61,10 @@ You can learn more in the
 [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+## Content Security Policy ([CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP))
+
+This application has been build with a [strict content security policy](https://csp.withgoogle.com/docs/strict-csp.html). To enforce this policy
+add the following CSP header to the request response.
+
+`Content-Security-Policy: script-src 'sha256-+OVgFCkyF2/rZ6qyfsNnIisCRI6dtMZw3w0Y4xiYagw=' 'strict-dynamic' https: 'unsafe-inline'; object-src 'none'; base-uri 'none';`

--- a/standard/template/build-tools/scripts/clean-index-template.ts
+++ b/standard/template/build-tools/scripts/clean-index-template.ts
@@ -1,0 +1,14 @@
+import * as path from 'path';
+import { readFile, writeFile } from 'fs/promises';
+
+/**
+ * This script executes post build and rewrites the index.html file removing
+ * injected scripts from the build.
+ */
+(async () => {
+  const index = path.resolve('./build/index.html');
+  const contents = await readFile(index, { encoding: 'utf-8' });
+  const cleaned = contents.replace(/<script src="[\w\d-\/]*static\/js\/[\w\d\.-]*"><\/script>/ig,'');
+
+  await writeFile(index, cleaned, { encoding: 'utf-8' });
+})();

--- a/standard/template/public/index.html
+++ b/standard/template/public/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="utf-8" />
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
@@ -8,6 +7,14 @@
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Web site created using create-react-app" />
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon.ico" />
+
+  <% if(process.env.NODE_ENV === 'development') { %>
+  <meta http-equiv="Content-Security-Policy" content="script-src 'sha256-+OVgFCkyF2/rZ6qyfsNnIisCRI6dtMZw3w0Y4xiYagw=' 'strict-dynamic' https: 'unsafe-inline'; object-src 'none'; base-uri 'none';">
+  <% } %>
+
+  <% for (var chunk in htmlWebpackPlugin.files.js) { %>
+  <meta name="app-script" content="<%= htmlWebpackPlugin.files.js[chunk]%>" />
+  <% } %>
   <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -23,18 +30,23 @@
     -->
   <title>React App</title>
 </head>
-
 <body>
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root"></div>
-  <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-</body>
+<noscript>You need to enable JavaScript to run this app.</noscript>
+<div id="root"></div>
+<!--
+    This HTML file is a template.
+    If you open it directly in the browser, you will see an empty page.
+    You can add webfonts, meta tags, or analytics to this file.
+    The build step will place the bundled scripts into the <body> tag.
+    To begin the development, run `npm start` or `yarn start`.
+    To create a production bundle, use `npm run build` or `yarn build`.
+  -->
 
+<script>!function(){for(var o=document.querySelectorAll('html > head > meta[name="app-script"]'),t=0;t<o.length;t++){var e=o[t].getAttribute("content"),n=document.createElement("script");n.src=e,n.src.substr(0,window.location.origin.length)!==window.location.origin?window.console&&console.error("[ScriptLoader] Cannot load "+e+"."):document.body.appendChild(n)}}()</script>
+
+<% if(process.env.NODE_ENV === 'development') { %>
+<!-- workaround to skip cra automatic script injection -->
+<!-- </body></html>-->
+<% } %>
+</body>
 </html>


### PR DESCRIPTION
These changes allow React skeletons to run under a [strict Content Security Policy](https://csp.withgoogle.com/docs/strict-csp.html). 

The strict CSP will be applied in development mode, which should prevent "surprises" on build time. However strict CSP isn't automatically enabled whenever running a build, so it's an opt-in solution. The CSP header as listed in the <meta http-equiv="Content-Security-Policy" ... /> should be added to server response as well.